### PR TITLE
displayed networkswithcer in navbar -- removed from sidebar

### DIFF
--- a/apps/web/src/components/Menu/index.tsx
+++ b/apps/web/src/components/Menu/index.tsx
@@ -20,7 +20,6 @@ const LinkComponent = (linkProps) => {
 }
 
 const Menu = (props) => {
-  const [isSmallScreen, setIsSmallScreen] = useState(false)
   const { chainId } = useActiveChainId()
   const { isDark, setTheme } = useTheme()
   const cakePriceUsd = useCakeBusdPrice({ forceMainnet: true })
@@ -42,18 +41,6 @@ const Menu = (props) => {
     return footerLinks(t)
   }, [t])
 
-  useEffect(() => {
-  const handleResize = () => {
-    setIsSmallScreen(window.innerWidth < 1024)
-  }
-
-  handleResize()
-  window.addEventListener('resize', handleResize)
-  return () => window.removeEventListener('resize', handleResize)
-  }, [])
-
-const shouldHideNetworkSwitcher = pathname.includes('/dashboard') && isSmallScreen
-
   return (
     <>
       <UikitMenu
@@ -61,9 +48,7 @@ const shouldHideNetworkSwitcher = pathname.includes('/dashboard') && isSmallScre
         rightSide={
           <>
             {/* <GlobalSettings mode={SettingsMode.GLOBAL} /> */}
-            {!shouldHideNetworkSwitcher && (
-                <NetworkSwitcher />
-            )}
+            <NetworkSwitcher />
             <UserMenu />
           </>
         }
@@ -82,7 +67,6 @@ const shouldHideNetworkSwitcher = pathname.includes('/dashboard') && isSmallScre
         activeSubItem={activeSubMenuItem?.href}
         buyCakeLabel={t('Buy KFC')}
         buyCakeLink=""
-        shouldHideNetworkSwitcher={shouldHideNetworkSwitcher}
         // buyCakeLabel={t('Buy CAKE')}
         // buyCakeLink="https://pancakeswap.finance/swap?outputCurrency=0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82&chainId=56"
         {...props}

--- a/apps/web/src/views/Dashboard/components/Sidebar.tsx
+++ b/apps/web/src/views/Dashboard/components/Sidebar.tsx
@@ -16,8 +16,7 @@ import { LaunchWeek } from '../icons/launchweek.ico'
 import { EngagmentIcons } from '../icons/engagments.ico'
 import { routePermissions } from '../types/enums'
 import { LockedIcon } from '../icons/lock.ico'
-import { NetworkSwitcher } from 'components/NetworkSwitcher'
-import { getSidebarOpen, subscribeToSidebar } from '@pancakeswap/uikit/src/hooks/useSideBarOpenForDashBoard'
+import { getSidebarOpen, subscribeToSidebar, setSidebarOpen } from '@pancakeswap/uikit/src/hooks/useSideBarOpenForDashBoard'
 
 interface MenuWrapperProps {
   isBorder?: boolean
@@ -261,14 +260,13 @@ const SideBar = ({ permissions: data, isLoading = true }: SideBarProps) => {
   return (
     <>
       {/* Overlay for mobile */}
-      {open && <Overlay onClick={() => setOpen(false)} />}
+      {open && <Overlay onClick={() => setSidebarOpen(!open)} />}
 
       {/* Sidebar */}
       <SideBarWrapper open={open}>
         <ResponsiveBox>
           <Flex width="100%" flexDirection="column">
             <MenuContainer>
-              {open && <NetworkSwitcher />}
               {menuItems.map((item, index) => {
                 const requiredPermission = routePermissions[item.href as keyof typeof routePermissions]
                 const hasPermission =

--- a/packages/uikit/src/widgets/Menu/Menu.tsx
+++ b/packages/uikit/src/widgets/Menu/Menu.tsx
@@ -130,7 +130,6 @@ const Menu: React.FC<React.PropsWithChildren<NavProps>> = ({
   children,
   chainId,
   logoComponent,
-  shouldHideNetworkSwitcher,
 }) => {
   const { isMobile } = useMatchBreakpoints();
   const isMounted = useIsMounted();
@@ -189,7 +188,6 @@ const Menu: React.FC<React.PropsWithChildren<NavProps>> = ({
             <StyledNav id="nav">
               <Flex alignItems="center" height="100%" justifyContent="space-between" paddingX="15px" style={{ gap: "15px" }}>
                 {/* Hamburger Icon */}
-                {shouldHideNetworkSwitcher && (
                   <Hamburger onClick={() => setSidebarOpen(!open)}>
                     {open ? (
                       <HamburgerCloseIcon style={{ transform: "scale(1.31)" }} />
@@ -197,7 +195,6 @@ const Menu: React.FC<React.PropsWithChildren<NavProps>> = ({
                       <HamburgerIcon style={{ transform: "scale(1.31)" }} />
                     )}
                   </Hamburger>
-                )}
                 <Flex>{logoComponent ?? <Logo href={homeLink_ ?? homeLink?.href ?? "/"} />}</Flex>
               </Flex>
               <Flex alignItems="center" height="100%">

--- a/packages/uikit/src/widgets/Menu/types.ts
+++ b/packages/uikit/src/widgets/Menu/types.ts
@@ -33,5 +33,4 @@ export interface NavProps {
   chainId: number;
   setLang: (lang: Language) => void;
   logoComponent?: ReactNode;
-  shouldHideNetworkSwitcher?: boolean;
 }


### PR DESCRIPTION
Removed  `<NetworkSwitcher />` From SideBar For mobile view and displayed that directly in navbar

<img width="244" height="175" alt="image" src="https://github.com/user-attachments/assets/01041009-52a4-4929-93d6-8ac68a1866d7" />
